### PR TITLE
Added `[clamping:]` to `RandomAccessCollection`

### DIFF
--- a/Sources/SafeCollectionAccess/Safe Collection Access.swift
+++ b/Sources/SafeCollectionAccess/Safe Collection Access.swift
@@ -8,6 +8,8 @@
 
 
 
+// MARK: - `[orNil: ]` and `[safe: ]`
+
 public extension RandomAccessCollection {
     
     /// Safely access this collection. If the index you pass is not in this collection, then `nil` is returned.
@@ -31,5 +33,34 @@ public extension RandomAccessCollection {
     @inline(__always)
     subscript(safe index: Index) -> Element? {
         return self[orNil: index]
+    }
+}
+
+
+
+// MARK: - `[clamping: ]`
+
+public extension RandomAccessCollection {
+    
+    /// Safely access this collection. If the index you pass is not in this collection, the closest extreme is
+    /// returned. If this collection is empty (and thus there is no such extreme to return), then `nil` is returned.
+    ///
+    /// - Parameter index: The index of the element to retrieve, or an index outside this collection
+    /// - Returns: The element which is in this collection at the given index, or the closest one if it's outside this
+    ///            collection, or `nil` if this collection is empty
+    @inlinable
+    subscript(clamping index: Index) -> Element? {
+        if isEmpty {
+            return nil
+        }
+        else if index < startIndex {
+            return first
+        }
+        else if index >= endIndex {
+            return last
+        }
+        else {
+            return self[index]
+        }
     }
 }

--- a/Tests/SafeCollectionAccessTests/SafeCollectionAccessTests.swift
+++ b/Tests/SafeCollectionAccessTests/SafeCollectionAccessTests.swift
@@ -13,9 +13,10 @@ import XCTest
 
 final class SafeCollectionAccessTests: XCTestCase {
     
+    let first5Fibonacci = [1, 1, 2, 3, 5]
+    
+    
     func testSubscriptOrNil() {
-        let first5Fibonacci = [1, 1, 2, 3, 5]
-
         XCTAssertEqual(1, first5Fibonacci[orNil: 0])
         XCTAssertEqual(1, first5Fibonacci[orNil: 1])
         XCTAssertEqual(2, first5Fibonacci[orNil: 2])
@@ -41,8 +42,6 @@ final class SafeCollectionAccessTests: XCTestCase {
     
     
     func testSubscriptSafe() {
-        let first5Fibonacci = [1, 1, 2, 3, 5]
-
         XCTAssertEqual(1, first5Fibonacci[safe: 0])
         XCTAssertEqual(1, first5Fibonacci[safe: 1])
         XCTAssertEqual(2, first5Fibonacci[safe: 2])
@@ -68,8 +67,6 @@ final class SafeCollectionAccessTests: XCTestCase {
     
     
     func testSubscriptClamping() {
-        let first5Fibonacci = [1, 1, 2, 3, 5]
-
         XCTAssertEqual(1, first5Fibonacci[clamping: 0])
         XCTAssertEqual(1, first5Fibonacci[clamping: 1])
         XCTAssertEqual(2, first5Fibonacci[clamping: 2])

--- a/Tests/SafeCollectionAccessTests/SafeCollectionAccessTests.swift
+++ b/Tests/SafeCollectionAccessTests/SafeCollectionAccessTests.swift
@@ -67,8 +67,54 @@ final class SafeCollectionAccessTests: XCTestCase {
     }
     
     
+    func testSubscriptClamping() {
+        let first5Fibonacci = [1, 1, 2, 3, 5]
+
+        XCTAssertEqual(1, first5Fibonacci[clamping: 0])
+        XCTAssertEqual(1, first5Fibonacci[clamping: 1])
+        XCTAssertEqual(2, first5Fibonacci[clamping: 2])
+        XCTAssertEqual(3, first5Fibonacci[clamping: 3])
+        XCTAssertEqual(5, first5Fibonacci[clamping: 4])
+        
+        XCTAssertEqual(first5Fibonacci[clamping: -1], first5Fibonacci[clamping: 0])
+        XCTAssertEqual(first5Fibonacci[clamping: 0], first5Fibonacci[clamping: 1])
+        XCTAssertNotEqual(first5Fibonacci[clamping: 1], first5Fibonacci[clamping: 2])
+        XCTAssertNotEqual(first5Fibonacci[clamping: 2], first5Fibonacci[clamping: 3])
+        XCTAssertNotEqual(first5Fibonacci[clamping: 3], first5Fibonacci[clamping: 4])
+        
+        XCTAssertNotNil(first5Fibonacci[clamping: -2])
+        XCTAssertNotNil(first5Fibonacci[clamping: -1])
+        XCTAssertNotNil(first5Fibonacci[clamping: 0])
+        XCTAssertNotNil(first5Fibonacci[clamping: 1])
+        XCTAssertNotNil(first5Fibonacci[clamping: 2])
+        XCTAssertNotNil(first5Fibonacci[clamping: 3])
+        XCTAssertNotNil(first5Fibonacci[clamping: 4])
+        XCTAssertNotNil(first5Fibonacci[clamping: 5])
+        XCTAssertNotNil(first5Fibonacci[clamping: 6])
+        
+        
+        let collectionOfOne = [42]
+        
+        XCTAssertEqual(42, collectionOfOne[clamping: -2])
+        XCTAssertEqual(42, collectionOfOne[clamping: -1])
+        XCTAssertEqual(42, collectionOfOne[clamping: 0])
+        XCTAssertEqual(42, collectionOfOne[clamping: 1])
+        XCTAssertEqual(42, collectionOfOne[clamping: 2])
+        
+        
+        let emptyCollection = [Int]()
+        
+        XCTAssertNil(emptyCollection[clamping: -2])
+        XCTAssertNil(emptyCollection[clamping: -1])
+        XCTAssertNil(emptyCollection[clamping: 0])
+        XCTAssertNil(emptyCollection[clamping: 1])
+        XCTAssertNil(emptyCollection[clamping: 2])
+    }
+    
+    
     static var allTests = [
         ("testSubscriptOrNil", testSubscriptOrNil),
         ("testSubscriptSafe", testSubscriptSafe),
+        ("testSubscriptClamping", testSubscriptClamping),
     ]
 }


### PR DESCRIPTION
Like `[orNil:]`, this won't crash when you access indices outside the collection but instead of returning `nil` for those, `[clamped:]` will return the element at the closest extreme. If the collection is empty, then there is no such extreme, and so it will return `nil`.